### PR TITLE
Podspec update for tvos

### DIFF
--- a/UIView+BooleanAnimations.podspec
+++ b/UIView+BooleanAnimations.podspec
@@ -9,7 +9,9 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/ashfurrow/UIView-BooleanAnimations"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "Ash Furrow" => "ash@ashfurrow.com", "Orta Therox" => "orta.therox@gmail.com", "Laura Brown" => "laurabrown1113@gmail.com" }
-  s.platform     = :ios, "7.0"
+  
+  s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.0'
   s.source       = { :git => "https://github.com/ashfurrow/UIView-BooleanAnimations.git", :tag => "#{ s.version }" }
   s.source_files = "UIView+BooleanAnimations.{h,m}"
   s.framework    = "UIKit"


### PR DESCRIPTION
The podspec should be updated for tvOS. As far as I could see, all the API's are still working under tvOS.
